### PR TITLE
feat: support custom base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ Open your browser to `http://localhost:8080` to view the dashboard.
 
 ### REST Endpoints
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/api/config` | Get server configuration |
-| `GET` | `/api/jobs` | List all jobs |
-| `GET` | `/api/jobs/{id}` | Get job details |
-| `POST` | `/api/jobs/{id}/run` | Execute job immediately |
-| `DELETE` | `/api/jobs/{id}` | Remove job from scheduler |
-| `POST` | `/api/scheduler/start` | Start the scheduler |
-| `POST` | `/api/scheduler/stop` | Stop the scheduler |
+| Method   | Endpoint               | Description               |
+| -------- | ---------------------- | ------------------------- |
+| `GET`    | `/api/config`          | Get server configuration  |
+| `GET`    | `/api/jobs`            | List all jobs             |
+| `GET`    | `/api/jobs/{id}`       | Get job details           |
+| `POST`   | `/api/jobs/{id}/run`   | Execute job immediately   |
+| `DELETE` | `/api/jobs/{id}`       | Remove job from scheduler |
+| `POST`   | `/api/scheduler/start` | Start the scheduler       |
+| `POST`   | `/api/scheduler/stop`  | Stop the scheduler        |
 
 ### WebSocket
 
@@ -141,7 +141,12 @@ go run main.go
 Visit `http://localhost:8080` to see the UI in action.
 
 ### Basic Auth
+
 See the [basic_auth](./examples/basic_auth) example for how to secure GoCron-UI using a simple basic auth middleware with the credentials being sourced via environment variables.
+
+### Custom base path
+
+See the [base_path](./examples/base_path) example for how to serve GoCron-UI behind a custom base path (e.g., `/admin/cron/`).
 
 ## Deployment
 

--- a/examples/base_path/README.md
+++ b/examples/base_path/README.md
@@ -1,0 +1,94 @@
+# GoCronUI Base Path Example
+
+This is a simple example demonstrating using gocron-ui behind a base path (e.g., `/admin/cron/`) and using the standard http.Handler interface to serve the application.
+
+```go
+go run main.go
+```
+
+You can access the web UI at [http://localhost:8080/admin/cron/](http://localhost:8080/admin/cron/).
+
+To access the API:
+
+```bash
+$ curl http://127.0.0.1:8080/admin/cron/api/jobs -v | jq .
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8080...
+* Connected to 127.0.0.1 (127.0.0.1) port 8080
+> GET /admin/cron/api/jobs HTTP/1.1
+> Host: 127.0.0.1:8080
+> User-Agent: curl/8.7.1
+> Accept: */*
+>
+* Request completely sent off
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< Vary: Origin
+< Date: Thu, 15 Jan 2026 21:56:15 GMT
+< Content-Length: 1187
+<
+{ [1187 bytes data]
+
+100  1187  100  1187    0     0  1074k      0 --:--:-- --:--:-- --:--:-- 1159k
+* Connection #0 to host 127.0.0.1 left intact
+[
+  {
+    "id": "15fde994-9cde-4c82-a9e5-6fea65da1bc6",
+    "name": "simple-5s-interval",
+    "tags": [
+      "interval",
+      "simple"
+    ],
+    "nextRun": "2026-01-15T22:56:19+01:00",
+    "lastRun": "2026-01-15T22:56:14+01:00",
+    "nextRuns": [
+      "2026-01-15T22:56:19+01:00",
+      "2026-01-15T22:56:24+01:00",
+      "2026-01-15T22:56:29+01:00",
+      "2026-01-15T22:56:34+01:00",
+      "2026-01-15T22:56:39+01:00"
+    ],
+    "schedule": "Every 5 seconds",
+    "scheduleDetail": "Duration: 5s"
+  },
+  {
+    "id": "6996c9b5-8444-4534-a0d4-7f2c7dc09717",
+    "name": "simple-10s-interval",
+    "tags": [
+      "interval",
+      "simple"
+    ],
+    "nextRun": "2026-01-15T22:56:24+01:00",
+    "lastRun": "2026-01-15T22:56:14+01:00",
+    "nextRuns": [
+      "2026-01-15T22:56:24+01:00",
+      "2026-01-15T22:56:34+01:00",
+      "2026-01-15T22:56:44+01:00",
+      "2026-01-15T22:56:54+01:00",
+      "2026-01-15T22:57:04+01:00"
+    ],
+    "schedule": "Every 10 seconds",
+    "scheduleDetail": "Duration: 10s"
+  },
+  {
+    "id": "7a5a5965-f56a-4cfe-9abd-5dc91aff5cdd",
+    "name": "simple-20s-interval",
+    "tags": [
+      "interval",
+      "simple"
+    ],
+    "nextRun": "2026-01-15T22:56:24+01:00",
+    "lastRun": "2026-01-15T22:56:04+01:00",
+    "nextRuns": [
+      "2026-01-15T22:56:24+01:00",
+      "2026-01-15T22:56:44+01:00",
+      "2026-01-15T22:57:04+01:00",
+      "2026-01-15T22:57:24+01:00",
+      "2026-01-15T22:57:44+01:00"
+    ],
+    "schedule": "Every 20 seconds",
+    "scheduleDetail": "Duration: 20s"
+  }
+]

--- a/examples/base_path/main.go
+++ b/examples/base_path/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-co-op/gocron-ui/server"
+	"github.com/go-co-op/gocron/v2"
+)
+
+var jobs = []struct {
+	name       string
+	definition gocron.JobDefinition
+	task       gocron.Task
+	options    []gocron.JobOption
+}{
+	{
+		"simple-10s-interval", gocron.DurationJob(10 * time.Second), gocron.NewTask(func() { log.Println("Running 10-second interval job") }), []gocron.JobOption{gocron.WithName("simple-10s-interval"), gocron.WithTags("interval", "simple")},
+	},
+	{
+		"simple-5s-interval", gocron.DurationJob(5 * time.Second), gocron.NewTask(func() { log.Println("Running 5-second interval job") }), []gocron.JobOption{gocron.WithName("simple-5s-interval"), gocron.WithTags("interval", "simple")},
+	},
+	{
+		"simple-20s-interval", gocron.DurationJob(20 * time.Second), gocron.NewTask(func() { log.Println("Running 20-second interval job") }), []gocron.JobOption{gocron.WithName("simple-20s-interval"), gocron.WithTags("interval", "simple")},
+	},
+}
+
+func main() {
+	port := flag.Int("port", 8080, "Port to run the server on")
+	title := flag.String("title", "GoCron Scheduler", "Custom title for the UI")
+	flag.Parse()
+
+	// create the gocron scheduler
+	scheduler, err := gocron.NewScheduler()
+	if err != nil {
+		log.Fatalf("Failed to create scheduler: %v", err)
+	}
+
+	// add jobs to the scheduler
+	for _, job := range jobs {
+		if _, err := scheduler.NewJob(job.definition, job.task, job.options...); err != nil {
+			log.Printf("Error creating job: %v", err)
+		}
+	}
+
+	// start the scheduler
+	scheduler.Start()
+	log.Println("Scheduler started with", len(scheduler.Jobs()), "jobs")
+
+	// create and start the API server with custom title and a custom path
+	basePath := "/admin/cron/"
+	srv := server.NewServer(scheduler, *port, server.WithTitle(*title), server.WithBasePath(basePath))
+	router := http.NewServeMux()
+	router.Handle(basePath, srv.Router)
+
+	// start server in a goroutine
+	go func() {
+		addr := fmt.Sprintf(":%d", *port)
+		log.Println("\n" + strings.Repeat("=", 70))
+		log.Printf("GoCron UI Server Started")
+		log.Println(strings.Repeat("=", 70))
+		log.Printf("Web UI:       http://localhost%s/admin/cron/", addr)
+		log.Printf("API:          http://localhost%s/admin/cron/api", addr)
+		log.Printf("WebSocket:    ws://localhost%s/admin/cron/ws", addr)
+		log.Printf("Total Jobs:   %d", len(scheduler.Jobs()))
+		log.Println(strings.Repeat("=", 70) + "\n")
+
+		if err := http.ListenAndServe(addr, router); err != nil {
+			log.Fatalf("Server failed to start: %v", err)
+		}
+	}()
+
+	// wait for interrupt signal to gracefully shutdown
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	log.Println("\nShutting down server...")
+
+	// shutdown scheduler
+	if err := scheduler.Shutdown(); err != nil {
+		log.Printf("Error shutting down scheduler: %v", err)
+	}
+
+	log.Println("Server stopped gracefully")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	wsMutex   sync.RWMutex
 	upgrader  websocket.Upgrader
 	config    Config
+	basePath  string
 }
 
 // Config is the server configuration in which user can set the title of the UI
@@ -56,7 +57,8 @@ func NewServer(scheduler gocron.Scheduler, _ int, opts ...Option) *Server {
 				return true // allow all origins for development
 			},
 		},
-		config: defaultConfig(),
+		config:   defaultConfig(),
+		basePath: "/",
 	}
 
 	// apply options
@@ -65,6 +67,9 @@ func NewServer(scheduler gocron.Scheduler, _ int, opts ...Option) *Server {
 	}
 
 	router := mux.NewRouter()
+	if s.basePath != "/" {
+		router = router.PathPrefix(s.basePath).Subrouter()
+	}
 
 	if s.config.APIEnabled {
 		// api routes
@@ -89,7 +94,9 @@ func NewServer(scheduler gocron.Scheduler, _ int, opts ...Option) *Server {
 	if err != nil {
 		log.Fatalf("Failed to load static files: %v", err)
 	}
-	router.PathPrefix("/").Handler(http.FileServer(http.FS(staticFS)))
+
+	handler := http.FileServer(http.FS(staticFS))
+	router.PathPrefix("/").Handler(http.StripPrefix(s.basePath, handler))
 
 	// setup CORS
 	c := cors.New(cors.Options{
@@ -128,6 +135,16 @@ func WithAPIDisabled() Option {
 func WithWebSocketDisabled() Option {
 	return func(s *Server) {
 		s.config.WebSocketEnabled = false
+	}
+}
+
+// WithBasePath sets a base path for the server
+func WithBasePath(path string) Option {
+	return func(s *Server) {
+		s.basePath = strings.TrimRight(path, "/")
+		if s.basePath == "" {
+			s.basePath = "/"
+		}
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -14,6 +14,7 @@ import (
 func TestServerWithGorillaDefaults(t *testing.T) {
 	t.Run("get index page", func(t *testing.T) {
 		res := sendGetRequest(t, "/", "")
+		defer res.Body.Close()
 
 		expectStatusCode(t, res, http.StatusOK)
 		expectHeader(t, res, "Content-Type", "text/html; charset=utf-8")
@@ -21,6 +22,7 @@ func TestServerWithGorillaDefaults(t *testing.T) {
 
 	t.Run("get api config", func(t *testing.T) {
 		res := sendGetRequest(t, "/api/config", "")
+		defer res.Body.Close()
 
 		expectStatusCode(t, res, http.StatusOK)
 		expectHeader(t, res, "Content-Type", "application/json")
@@ -31,6 +33,7 @@ func TestServerWithGorillaDefaults(t *testing.T) {
 func TestServerWithGorillaDefaultsBehindHTTPDefaultMux(t *testing.T) {
 	t.Run("get index page", func(t *testing.T) {
 		res := sendGetRequest(t, "/", "/")
+		defer res.Body.Close()
 
 		expectStatusCode(t, res, http.StatusOK)
 		expectHeader(t, res, "Content-Type", "text/html; charset=utf-8")
@@ -38,6 +41,7 @@ func TestServerWithGorillaDefaultsBehindHTTPDefaultMux(t *testing.T) {
 
 	t.Run("get api config", func(t *testing.T) {
 		res := sendGetRequest(t, "/api/config", "/")
+		defer res.Body.Close()
 
 		expectStatusCode(t, res, http.StatusOK)
 		expectHeader(t, res, "Content-Type", "application/json")
@@ -48,6 +52,7 @@ func TestServerWithGorillaDefaultsBehindHTTPDefaultMux(t *testing.T) {
 func TestServerBehindPathMux(t *testing.T) {
 	t.Run("get index page", func(t *testing.T) {
 		res := sendGetRequest(t, "/admin/", "/admin/", server.WithBasePath("/admin/"))
+		defer res.Body.Close()
 
 		expectStatusCode(t, res, http.StatusOK)
 		expectHeader(t, res, "Content-Type", "text/html; charset=utf-8")
@@ -55,14 +60,13 @@ func TestServerBehindPathMux(t *testing.T) {
 
 	t.Run("get api config", func(t *testing.T) {
 		res := sendGetRequest(t, "/admin/api/config", "/admin/", server.WithBasePath("/admin/"))
+		defer res.Body.Close()
 
 		expectStatusCode(t, res, http.StatusOK)
 		expectHeader(t, res, "Content-Type", "application/json")
 		expectBody(t, res, `{"title":"GoCron UI","api_enabled":true,"websocket_enabled":true}`)
 	})
 }
-
-// normal usage using gorilla
 
 func sendGetRequest(t *testing.T, reqPath, muxPath string, opts ...server.Option) *http.Response {
 	t.Helper()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,118 @@
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-co-op/gocron-ui/server"
+	"github.com/go-co-op/gocron/v2"
+)
+
+func TestServerWithGorillaDefaults(t *testing.T) {
+	t.Run("get index page", func(t *testing.T) {
+		res := sendGetRequest(t, "/", "")
+
+		expectStatusCode(t, res, http.StatusOK)
+		expectHeader(t, res, "Content-Type", "text/html; charset=utf-8")
+	})
+
+	t.Run("get api config", func(t *testing.T) {
+		res := sendGetRequest(t, "/api/config", "")
+
+		expectStatusCode(t, res, http.StatusOK)
+		expectHeader(t, res, "Content-Type", "application/json")
+		expectBody(t, res, `{"title":"GoCron UI","api_enabled":true,"websocket_enabled":true}`)
+	})
+}
+
+func TestServerWithGorillaDefaultsBehindHTTPDefaultMux(t *testing.T) {
+	t.Run("get index page", func(t *testing.T) {
+		res := sendGetRequest(t, "/", "/")
+
+		expectStatusCode(t, res, http.StatusOK)
+		expectHeader(t, res, "Content-Type", "text/html; charset=utf-8")
+	})
+
+	t.Run("get api config", func(t *testing.T) {
+		res := sendGetRequest(t, "/api/config", "/")
+
+		expectStatusCode(t, res, http.StatusOK)
+		expectHeader(t, res, "Content-Type", "application/json")
+		expectBody(t, res, `{"title":"GoCron UI","api_enabled":true,"websocket_enabled":true}`)
+	})
+}
+
+func TestServerBehindPathMux(t *testing.T) {
+	t.Run("get index page", func(t *testing.T) {
+		res := sendGetRequest(t, "/admin/", "/admin/", server.WithBasePath("/admin/"))
+
+		expectStatusCode(t, res, http.StatusOK)
+		expectHeader(t, res, "Content-Type", "text/html; charset=utf-8")
+	})
+
+	t.Run("get api config", func(t *testing.T) {
+		res := sendGetRequest(t, "/admin/api/config", "/admin/", server.WithBasePath("/admin/"))
+
+		expectStatusCode(t, res, http.StatusOK)
+		expectHeader(t, res, "Content-Type", "application/json")
+		expectBody(t, res, `{"title":"GoCron UI","api_enabled":true,"websocket_enabled":true}`)
+	})
+}
+
+// normal usage using gorilla
+
+func sendGetRequest(t *testing.T, reqPath, muxPath string, opts ...server.Option) *http.Response {
+	t.Helper()
+
+	scheduler, _ := gocron.NewScheduler()
+	srv := server.NewServer(scheduler, 8080, opts...)
+	if muxPath != "" {
+		mux := http.NewServeMux()
+		mux.Handle(muxPath, srv.Router)
+		return sendGetRequestToServer(t, reqPath, mux)
+	}
+
+	return sendGetRequestToServer(t, reqPath, srv.Router)
+}
+
+func sendGetRequestToServer(t *testing.T, path string, srv http.Handler) *http.Response {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "http://example.com"+path, nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, req)
+	return w.Result()
+}
+
+func expectStatusCode(t *testing.T, res *http.Response, expectedStatusCode int) {
+	t.Helper()
+	if res.StatusCode != expectedStatusCode {
+		t.Fatalf("expected status code %d; got %d", expectedStatusCode, res.StatusCode)
+	}
+}
+
+func expectHeader(t *testing.T, res *http.Response, key, expectedValue string) {
+	t.Helper()
+	actualValue := res.Header.Get(key)
+	if actualValue != expectedValue {
+		t.Fatalf("expected header %q to be %q; got %q", key, expectedValue, actualValue)
+	}
+}
+
+func expectBody(t *testing.T, res *http.Response, expectedBody string) {
+	t.Helper()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("error reading response body: %v", err)
+	}
+	res.Body.Close()
+
+	actualBody := strings.TrimSpace(string(data))
+	if actualBody != expectedBody {
+		t.Fatalf("expected body %q; got %q", expectedBody, actualBody)
+	}
+}


### PR DESCRIPTION
### What does this do?

Support serving gocron-ui behind a custom path in an existing `http.ServeMux`. Useful to add gocron-ui to existing apps that use the standard http API.

### Which issue(s) does this PR fix/relate to?

N/A

### List any changes that modify/break current functionality

N/A

### Have you included tests for your changes?

Of course :)

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [x] Updated `README.md`

### Notes
