### PR TITLE
feat: Add support for managing and displaying multiple gocron schedulers in the UI

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -26,6 +26,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.2
+          version: v2.11
       - name: test
         run: make test

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Open your browser to `http://localhost:8080` to view the dashboard.
 ## Features
 
 - **Real-time Monitoring** - WebSocket-based live job status updates
+- **Multi-Scheduler Support** - Monitor and control multiple scheduler instances in a single UI
 - **Job Control** - Trigger jobs manually or remove them from the scheduler
 - **Schedule Preview** - View upcoming executions for each job
 - **Tagging System** - Organize and filter jobs by tags
@@ -108,7 +109,8 @@ Connect to `ws://localhost:8080/ws` for real-time job updates.
       "lastRun": "2025-10-07T15:29:50Z",
       "nextRuns": ["...", "..."],
       "schedule": "Every 10 seconds",
-      "scheduleDetail": "Duration: 10s"
+      "scheduleDetail": "Duration: 10s",
+      "schedulerName": "Default"
     }
   ]
 }
@@ -188,6 +190,26 @@ srv := server.NewServer(scheduler, 8080, server.WithTitle("My Custom Scheduler")
 ```
 
 This will update both the browser tab title and the header title in the UI. When using a custom title, the UI automatically displays a subtle "powered by gocron-ui" attribution below the title.
+
+#### Multi-Scheduler Support
+
+You can register additional schedulers using the `WithAdditionalScheduler` option:
+
+```go
+s1, _ := gocron.NewScheduler()
+s2, _ := gocron.NewScheduler()
+
+// ... add jobs ...
+
+srv := server.NewServer(
+    s1, 
+    8080, 
+    server.WithTitle("Multi-Scheduler Dashboard"),
+    server.WithAdditionalScheduler("Background Tasks", s2),
+)
+```
+
+This allows you to monitor and control jobs from multiple schedulers in the same interface. Each job in the UI will display a badge indicating which scheduler it belongs to.
 
 #### Command-line Example
 

--- a/examples/getting_started/main.go
+++ b/examples/getting_started/main.go
@@ -130,25 +130,44 @@ func main() {
 	title := flag.String("title", "GoCron Scheduler", "Custom title for the UI")
 	flag.Parse()
 
-	// create the gocron scheduler
-	scheduler, err := gocron.NewScheduler()
+	// create the gocron schedulers
+	s1, err := gocron.NewScheduler()
 	if err != nil {
-		log.Fatalf("Failed to create scheduler: %v", err)
+		log.Fatalf("Failed to create scheduler 1: %v", err)
+	}
+	s2, err := gocron.NewScheduler()
+	if err != nil {
+		log.Fatalf("Failed to create scheduler 2: %v", err)
 	}
 
-	// add jobs to the scheduler
-	for _, job := range jobs {
-		if _, err := scheduler.NewJob(job.definition, job.task, job.options...); err != nil {
-			log.Printf("Error creating job: %v", err)
+	// add regular jobs to s1
+	for i := 0; i < 5; i++ {
+		job := jobs[i]
+		if _, err := s1.NewJob(job.definition, job.task, job.options...); err != nil {
+			log.Printf("Error creating job in s1: %v", err)
 		}
 	}
 
-	// start the scheduler
-	scheduler.Start()
-	log.Println("Scheduler started with", len(scheduler.Jobs()), "jobs")
+	// add remaining jobs to s2
+	for i := 5; i < len(jobs); i++ {
+		job := jobs[i]
+		if _, err := s2.NewJob(job.definition, job.task, job.options...); err != nil {
+			log.Printf("Error creating job in s2: %v", err)
+		}
+	}
 
-	// create and start the API server with custom title
-	srv := server.NewServer(scheduler, *port, server.WithTitle(*title))
+	// start the schedulers
+	s1.Start()
+	s2.Start()
+	log.Println("Schedulers started")
+
+	// create and start the API server with custom title and additional scheduler
+	srv := server.NewServer(
+		s1,
+		*port,
+		server.WithTitle(*title),
+		server.WithAdditionalScheduler("Background Tasks", s2),
+	)
 
 	// start server in a goroutine
 	go func() {
@@ -159,7 +178,7 @@ func main() {
 		log.Printf("Web UI:       http://localhost%s", addr)
 		log.Printf("API:          http://localhost%s/api", addr)
 		log.Printf("WebSocket:    ws://localhost%s/ws", addr)
-		log.Printf("Total Jobs:   %d", len(scheduler.Jobs()))
+		log.Printf("Total Jobs:   %d", len(s1.Jobs())+len(s2.Jobs()))
 		log.Println(strings.Repeat("=", 70) + "\n")
 
 		if err := http.ListenAndServe(addr, srv.Router); err != nil {
@@ -174,9 +193,12 @@ func main() {
 
 	log.Println("\nShutting down server...")
 
-	// shutdown scheduler
-	if err := scheduler.Shutdown(); err != nil {
-		log.Printf("Error shutting down scheduler: %v", err)
+	// shutdown schedulers
+	if err := s1.Shutdown(); err != nil {
+		log.Printf("Error shutting down scheduler 1: %v", err)
+	}
+	if err := s2.Shutdown(); err != nil {
+		log.Printf("Error shutting down scheduler 2: %v", err)
 	}
 
 	log.Println("Server stopped gracefully")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-co-op/gocron-ui
 
-go 1.25.0
+go 1.24
 
 require (
 	github.com/go-co-op/gocron/v2 v2.20.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-co-op/gocron-ui
 
-go 1.26.0
+go 1.25.0
 
 require (
 	github.com/go-co-op/gocron/v2 v2.20.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-co-op/gocron-ui
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/go-co-op/gocron/v2 v2.19.0

--- a/server/server.go
+++ b/server/server.go
@@ -21,14 +21,15 @@ import (
 //go:embed static/*
 var staticFiles embed.FS
 
-// Server is the main server struct which contains the scheduler, router, webSocket clients, webSocket mutex, upgrader, and config
+// Server is the main server struct which contains the schedulers, router, webSocket clients, webSocket mutex, upgrader, and config
 type Server struct {
-	Scheduler gocron.Scheduler
-	Router    http.Handler
-	wsClients map[*websocket.Conn]bool
-	wsMutex   sync.RWMutex
-	upgrader  websocket.Upgrader
-	config    Config
+	Schedulers     []gocron.Scheduler
+	SchedulerNames []string
+	Router         http.Handler
+	wsClients      map[*websocket.Conn]bool
+	wsMutex        sync.RWMutex
+	upgrader       websocket.Upgrader
+	config         Config
 }
 
 // Config is the server configuration in which user can set the title of the UI
@@ -49,8 +50,9 @@ func defaultConfig() Config {
 // NewServer creates a new server instance
 func NewServer(scheduler gocron.Scheduler, _ int, opts ...Option) *Server {
 	s := &Server{
-		Scheduler: scheduler,
-		wsClients: make(map[*websocket.Conn]bool),
+		Schedulers:     []gocron.Scheduler{scheduler},
+		SchedulerNames: []string{"Default"},
+		wsClients:      make(map[*websocket.Conn]bool),
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(_ *http.Request) bool {
 				return true // allow all origins for development
@@ -128,6 +130,14 @@ func WithAPIDisabled() Option {
 func WithWebSocketDisabled() Option {
 	return func(s *Server) {
 		s.config.WebSocketEnabled = false
+	}
+}
+
+// WithAdditionalScheduler adds an additional scheduler to the server
+func WithAdditionalScheduler(name string, scheduler gocron.Scheduler) Option {
+	return func(s *Server) {
+		s.Schedulers = append(s.Schedulers, scheduler)
+		s.SchedulerNames = append(s.SchedulerNames, name)
 	}
 }
 
@@ -226,12 +236,14 @@ func (s *Server) GetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jobs := s.Scheduler.Jobs()
-	for _, job := range jobs {
-		if job.ID() == id {
-			jobData := s.convertJobToData(job)
-			respondJSON(w, http.StatusOK, jobData)
-			return
+	for i, scheduler := range s.Schedulers {
+		jobs := scheduler.Jobs()
+		for _, job := range jobs {
+			if job.ID() == id {
+				jobData := s.convertJobToData(job, s.SchedulerNames[i])
+				respondJSON(w, http.StatusOK, jobData)
+				return
+			}
 		}
 	}
 
@@ -304,14 +316,14 @@ func (s *Server) CreateJob(w http.ResponseWriter, r *http.Request) {
 		options = append(options, gocron.WithTags(req.Tags...))
 	}
 
-	// add job to scheduler
-	job, err := s.Scheduler.NewJob(jobDef, task, options...)
+	// add job to scheduler (default to the first one)
+	job, err := s.Schedulers[0].NewJob(jobDef, task, options...)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	jobData := s.convertJobToData(job)
+	jobData := s.convertJobToData(job, s.SchedulerNames[0])
 	respondJSON(w, http.StatusCreated, jobData)
 }
 
@@ -326,12 +338,14 @@ func (s *Server) DeleteJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.Scheduler.RemoveJob(id); err != nil { // remove job from scheduler using the job ID & RemoveJob is a method of the Scheduler interface
-		respondError(w, http.StatusNotFound, "Job not found")
-		return
+	for _, scheduler := range s.Schedulers {
+		if err := scheduler.RemoveJob(id); err == nil {
+			respondJSON(w, http.StatusOK, map[string]string{"message": "Job deleted successfully"})
+			return
+		}
 	}
 
-	respondJSON(w, http.StatusOK, map[string]string{"message": "Job deleted successfully"})
+	respondError(w, http.StatusNotFound, "Job not found")
 }
 
 // RunJob runs a job immediately
@@ -345,47 +359,55 @@ func (s *Server) RunJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jobs := s.Scheduler.Jobs()
-	for _, job := range jobs {
-		if job.ID() == id {
-			if err := job.RunNow(); err != nil {
-				respondError(w, http.StatusInternalServerError, err.Error())
+	for _, scheduler := range s.Schedulers {
+		jobs := scheduler.Jobs()
+		for _, job := range jobs {
+			if job.ID() == id {
+				if err := job.RunNow(); err != nil {
+					respondError(w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				respondJSON(w, http.StatusOK, map[string]string{"message": "Job executed"})
 				return
 			}
-			respondJSON(w, http.StatusOK, map[string]string{"message": "Job executed"})
-			return
 		}
 	}
 
 	respondError(w, http.StatusNotFound, "Job not found")
 }
 
-// StopScheduler stops the scheduler
+// StopScheduler stops all schedulers
 func (s *Server) StopScheduler(w http.ResponseWriter, _ *http.Request) {
-	if err := s.Scheduler.StopJobs(); err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
-		return
+	for _, scheduler := range s.Schedulers {
+		if err := scheduler.StopJobs(); err != nil {
+			respondError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 	}
-	respondJSON(w, http.StatusOK, map[string]string{"message": "Scheduler stopped"})
+	respondJSON(w, http.StatusOK, map[string]string{"message": "Schedulers stopped"})
 }
 
-// StartScheduler starts the scheduler
+// StartScheduler starts all schedulers
 func (s *Server) StartScheduler(w http.ResponseWriter, _ *http.Request) {
-	s.Scheduler.Start()
-	respondJSON(w, http.StatusOK, map[string]string{"message": "Scheduler started"})
+	for _, scheduler := range s.Schedulers {
+		scheduler.Start()
+	}
+	respondJSON(w, http.StatusOK, map[string]string{"message": "Schedulers started"})
 }
 
 // helper functions
 func (s *Server) getJobsData() []JobData {
-	jobs := s.Scheduler.Jobs()
-	result := make([]JobData, 0, len(jobs))
-	for _, job := range jobs {
-		result = append(result, s.convertJobToData(job))
+	var result []JobData
+	for i, scheduler := range s.Schedulers {
+		jobs := scheduler.Jobs()
+		for _, job := range jobs {
+			result = append(result, s.convertJobToData(job, s.SchedulerNames[i]))
+		}
 	}
 	return result
 }
 
-func (s *Server) convertJobToData(job gocron.Job) JobData {
+func (s *Server) convertJobToData(job gocron.Job, schedulerName string) JobData {
 	nextRun, _ := job.NextRun()
 	lastRun, _ := job.LastRun()
 
@@ -404,6 +426,7 @@ func (s *Server) convertJobToData(job gocron.Job) JobData {
 		NextRuns:       formatTimes(nextRuns),
 		Schedule:       schedule,
 		ScheduleDetail: scheduleDetail,
+		SchedulerName:  schedulerName,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -30,7 +30,7 @@ type Server struct {
 	wsMutex        sync.RWMutex
 	upgrader       websocket.Upgrader
 	config         Config
-  basePath  string
+	basePath       string
 }
 
 // Config is the server configuration in which user can set the title of the UI
@@ -145,7 +145,7 @@ func WithAdditionalScheduler(name string, scheduler gocron.Scheduler) Option {
 	return func(s *Server) {
 		s.Schedulers = append(s.Schedulers, scheduler)
 		s.SchedulerNames = append(s.SchedulerNames, name)
-  }
+	}
 }
 
 // WithBasePath sets a base path for the server

--- a/server/static/app.js
+++ b/server/static/app.js
@@ -251,6 +251,13 @@ function renderJobCard(job) {
                 </div>
             ` : ''}
 
+            <div class="job-info-item" style="margin-bottom: 1rem;">
+                <span class="job-info-label">Scheduler:</span>
+                <span class="job-info-value">
+                    <span class="scheduler-badge">${escapeHtml(job.schedulerName || 'Default')}</span>
+                </span>
+            </div>
+
             <div class="job-info">
                 <div class="job-info-item">
                     <span class="job-info-label">Next Run:</span>

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -533,6 +533,18 @@ body {
     font-size: 1rem;
 }
 
+.scheduler-badge {
+    background: #e9ecef;
+    color: #495057;
+    padding: 0.25rem 0.65rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #dee2e6;
+}
+
 .schedule-detail {
     font-size: 0.75rem;
     color: #666;

--- a/server/types.go
+++ b/server/types.go
@@ -10,6 +10,7 @@ type JobData struct {
 	NextRuns       []string `json:"nextRuns"`
 	Schedule       string   `json:"schedule"`       // human-readable schedule description
 	ScheduleDetail string   `json:"scheduleDetail"` // technical schedule details (cron expression, interval, etc.)
+	SchedulerName  string   `json:"schedulerName"`
 }
 
 // CreateJobRequest represents the request to create a new job


### PR DESCRIPTION
## Description
This PR addresses issue #20 by allowing the `gocron-ui` server to manage and display multiple `gocron.Scheduler` instances simultaneously.

### Key Changes:
- **Server**: Refactored [Server](cci:2://file:///Users/yash/Documents/personal/gocron-ui/server/server.go:24:0-32:1) struct to handle a slice of schedulers and introduced [WithAdditionalScheduler](cci:1://file:///Users/yash/Documents/personal/gocron-ui/server/server.go:135:0-141:1) functional option.
- **API**: Updated all endpoints (`/jobs`, `/jobs/{id}/run`, etc.) to search across all registered schedulers.
- **UI**: Added a "Scheduler" badge to job cards in the Web UI to distinguish between different scheduler instances.
- **Examples**: Updated the `getting_started` example to demonstrate multi-scheduler usage.

Closes #20